### PR TITLE
Resolve GO vet issue

### DIFF
--- a/pkg/ghevent/github_event_test.go
+++ b/pkg/ghevent/github_event_test.go
@@ -377,7 +377,6 @@ func TestNewSucceedsVariationsOpenedCreateNewTargetBranchesOnBranches(t *testing
 	for _, b := range branches {
 		ctj := GitHubEvent{}
 		err := json.Unmarshal([]byte(openedGithubEventJSON), &ctj)
-		fmt.Sprint(ctj)
 		if err != nil {
 			t.Fatalf("Encountered unexpected error %v", err)
 		}


### PR DESCRIPTION
Resolves issue reported by GO vet (cleaned up debugging code)

```bash
➜  acyl git:(master) make vet
go vet github.com/Pluto-tv/acyl/pkg/api github.com/Pluto-tv/acyl/pkg/config github.com/Pluto-tv/acyl/pkg/eventlogger github.com/Pluto-tv/acyl/pkg/ghapp github.com/Pluto-tv/acyl/pkg/ghclient github.com/Pluto-tv/acyl/pkg/ghevent github.com/Pluto-tv/acyl/pkg/locker github.com/Pluto-tv/acyl/pkg/match github.com/Pluto-tv/acyl/pkg/memfs github.com/Pluto-tv/acyl/pkg/metrics github.com/Pluto-tv/acyl/pkg/mocks github.com/Pluto-tv/acyl/pkg/models github.com/Pluto-tv/acyl/pkg/namegen github.com/Pluto-tv/acyl/pkg/nitro/context github.com/Pluto-tv/acyl/pkg/nitro/env github.com/Pluto-tv/acyl/pkg/nitro/errors github.com/Pluto-tv/acyl/pkg/nitro/images github.com/Pluto-tv/acyl/pkg/nitro/meta github.com/Pluto-tv/acyl/pkg/nitro/metahelm github.com/Pluto-tv/acyl/pkg/nitro/metrics github.com/Pluto-tv/acyl/pkg/nitro/notifier github.com/Pluto-tv/acyl/pkg/persistence github.com/Pluto-tv/acyl/pkg/persistence/golorem github.com/Pluto-tv/acyl/pkg/reap github.com/Pluto-tv/acyl/pkg/secrets github.com/Pluto-tv/acyl/pkg/slacknotifier github.com/Pluto-tv/acyl/pkg/spawner github.com/Pluto-tv/acyl/pkg/testhelper/localdb github.com/Pluto-tv/acyl/pkg/testhelper/testdatalayer
# github.com/Pluto-tv/acyl/pkg/ghevent
pkg/ghevent/github_event_test.go:380:13: result of fmt.Sprint call not used
```